### PR TITLE
Added Test Flight data to RD-180 and F-1 / F-1A

### DIFF
--- a/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/F1_Config.cfg
@@ -13,7 +13,11 @@
 //  Source 1: http://history.nasa.gov/ap12fj/pdf/a12_sa507-flightmanual.pdf
 //  Source 2: http://history.msfc.nasa.gov/saturn_apollo/documents/F-1_Engine.pdf
 //  Source 3: http://www.b14643.de/Spacerockets/Diverse/U.S._Rocket_engines/engines.htm
+//  Source 4: http://www.astronautix.com/f/f-1.html
+//  Source 5: Eyes Turned Skyward: https://www.alternatehistory.com/wiki/doku.php?id=timelines:eyes_turned_skyward_spacecraft_and_launch_vehicle_technical_data
+//  Source 6: NASA fact sheet on F-1 https://mix.msfc.nasa.gov/images/MEDIUM/9801771.jpg
 //  ==================================================
+
 @PART[*]:HAS[#engineType[F1]]:FOR[RealismOverhaulEngines]
 {
 	@title = F-1 Series
@@ -66,8 +70,9 @@
 		}
 		CONFIG
 		{
-			name = F-1A
-			minThrust = 9189.6
+			name = F-1A					// Based on info from Eyes Turned Skyward Wiki
+			
+			minThrust = 6892.2			// can throttle to 75%
 			maxThrust = 9189.6
 			massMult = 0.97673
 			heatProduction = 100
@@ -88,7 +93,7 @@
 				key = 1 270
 			}
 			techRequired = heavierRocketry
-			cost = 2000 // total guess for now
+			cost = 2000 				// total guess for now
 			
 			%ullage = True
 			%pressureFed = False
@@ -103,8 +108,6 @@
 				name = TEATEB
 				amount = 1
 			}
-			techRequired = heavierRocketry
-			cost = 0 // IIRC, there was no increase?
 		}
 	}
 	@MODULE[ModuleGimbal]
@@ -124,5 +127,32 @@
 		name = TEATEB
 		amount = 1
 		maxAmount = 1
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[F-1]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = F-1
+		ratedBurnTime = 165					// Source 6
+		ignitionReliabilityStart = 0.93		// There were never really any true failures of the F-1 though a couple times an engine burned out early
+		ignitionReliabilityEnd = 0.988
+		cycleReliabilityStart = 0.94
+		cycleReliabilityEnd = 0.985
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[F-1A]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = F-1A
+		ratedBurnTime = 180					// No data, but if throttable, let's say it would last longer
+		ignitionReliabilityStart = 0.96
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.96
+		cycleReliabilityEnd = 0.995
+		techTransfer = F-1:50
 	}
 }

--- a/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
+++ b/GameData/RealismOverhaul/Engine_Configs/RD180_Config.cfg
@@ -24,7 +24,7 @@
 		CONFIG
 		{
 			name = RD-180
-			minThrust = 1951.44
+			minThrust = 1951.44  // Can throttle down to 47%
 			maxThrust = 4152
 			heatProduction = 100
 			PROPELLANT
@@ -40,8 +40,8 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 338.4
-				key = 1 311.9
+				key = 0 338.4  // straight from NPO website
+				key = 1 311.9  // straight from NPO website
 			}
 			
 			ullage = True
@@ -76,5 +76,18 @@
 		amount = 1.0
 		maxAmount = 1.0
 		isTweakable = False
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]:HAS[@CONFIG[RD-180]],!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+	TESTFLIGHT
+	{
+		name = RD-180
+		ratedBurnTime = 255  // Atlas V 521 burn time according to Atlas V Misison Planners.PDF
+		ignitionReliabilityStart = 0.98  // there has never been a failure
+		ignitionReliabilityEnd = 0.995  // there has never been a failure
+		cycleReliabilityStart = 0.98  // there has never been a failure
+		cycleReliabilityEnd = 0.995  // there has never been a failure
 	}
 }


### PR DESCRIPTION
* Added rated burn times and reliability data for all three engines.
* Removed a duplicate entry on the F-1A config file for techRequired and cost.
* Allowed F-1A to throttle to 75% as is stated in the ETS Wiki